### PR TITLE
Update links to Query Language page

### DIFF
--- a/src/Ghostly.Uwp/Controls/QueryControl/QueryControl.xaml
+++ b/src/Ghostly.Uwp/Controls/QueryControl/QueryControl.xaml
@@ -45,7 +45,7 @@
                            Text="{x:Bind Error, Mode=OneWay}"
                            TextDecorations="Underline"/>
                 <HyperlinkButton Margin="0,10,0,0" HorizontalAlignment="Left"
-                                 NavigateUri="https://spectresystems.se/ghostly/docs/query"
+                                 NavigateUri="https://ghostlyapp.net/queries"
                                  Content="{strings:Localize Key=Query_Error_NeedHelp}" />
             </StackPanel>
         </winui:TeachingTip>

--- a/src/Ghostly.Uwp/Views/Dialogs/CreateCategoryView.xaml
+++ b/src/Ghostly.Uwp/Views/Dialogs/CreateCategoryView.xaml
@@ -58,7 +58,7 @@
 
         <!-- "What is this?" -->
         <HyperlinkButton HorizontalAlignment="Right"
-                             NavigateUri="https://spectresystems.se/ghostly/docs/query"
+                             NavigateUri="https://ghostlyapp.net/queries"
                              Content="{strings:Localize Key=CreateCategory_WhatIsThis}" />
 
         <!-- "Show total count" -->

--- a/src/Ghostly.Uwp/Views/Dialogs/CreateRuleView.xaml
+++ b/src/Ghostly.Uwp/Views/Dialogs/CreateRuleView.xaml
@@ -40,7 +40,7 @@
                    Foreground="Red" TextWrapping="Wrap"
                    Visibility="{Binding ExpressionError.Value, Mode=OneWay, Converter={StaticResource VisibleWhenNotEmpty}}" />
         <HyperlinkButton HorizontalAlignment="Right"
-                         NavigateUri="https://spectresystems.se/ghostly/docs/query"
+                         NavigateUri="https://ghostlyapp.net/queries"
                          Content="{strings:Localize Key=CreateRule_WhatIsThis}" />
 
         <!-- Consequences -->


### PR DESCRIPTION
This PR updates the query error and create rule links to point to the **ghostlyapp.net** domain. 

An example of one of these links below (i.e. Need help?)

![image](https://user-images.githubusercontent.com/6445534/148025155-9fad2527-20af-4e3c-ac38-07dcacb995ed.png)