### PR TITLE
Make global.json less strict

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
       "version": "6.0.100",
-      "rollForward": "latestFeature"
+      "rollForward": "latestMinor"
     }
   }

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
     "sdk": {
-      "version": "6.0.100"
+      "version": "6.0.100",
+      "rollForward": "latestFeature"
     }
   }


### PR DESCRIPTION
Make the `global.json` file allow newer .NET SDKs. This will accept `6.0.200` and `6.1.0` but not `7.0.0`.

See: https://docs.microsoft.com/en-us/dotnet/core/tools/global-json#rollforward

Currently I get the following error when trying to build Ghostly:

```
PS C:\Code\ghostly> dotnet tool restore
The command could not be loaded, possibly because:
  * You intended to execute a .NET application:
      The application 'tool' does not exist.
  * You intended to execute a .NET SDK command:
      A compatible .NET SDK was not found.

Requested SDK version: 6.0.100
global.json file: C:\Code\ghostly\global.json

Installed SDKs:
6.0.301 [C:\Program Files\dotnet\sdk]
6.0.400 [C:\Program Files\dotnet\sdk]

Install the [6.0.100] .NET SDK or update [C:\Code\ghostly\global.json] to match an installed SDK.

Learn about SDK resolution:
https://aka.ms/dotnet/sdk-not-found
```